### PR TITLE
0117128 - Ox7 release test error

### DIFF
--- a/src/Core/EasyCreditViewConfig.php
+++ b/src/Core/EasyCreditViewConfig.php
@@ -12,27 +12,26 @@ class EasyCreditViewConfig extends EasyCreditViewConfig_parent
     /** @var EasyCreditModuleSettings $moduleSettings */
     protected $moduleSettings;
 
-    /**
-     * @inheritDoc
-     */
-    public function __construct()
+    protected function getModuleSettings()
     {
-        parent::__construct();
-        $this->moduleSettings = $this->getServiceFromContainer(EasyCreditModuleSettings::class);
+        if (!$this->moduleSettings) {
+            $this->moduleSettings = $this->getServiceFromContainer(EasyCreditModuleSettings::class);
+        }
+        return $this->moduleSettings;
     }
 
     public function getOxpsECExampleCalcBasket()
     {
-        return $this->moduleSettings->getOxpsECExampleCalcBasket();
+        return $this->getModuleSettings()->getOxpsECExampleCalcBasket();
     }
 
     public function getOxpsECExampleCalcMinibasket()
     {
-        return $this->moduleSettings->getOxpsECExampleCalcMinibasket();
+        return $this->getModuleSettings()->getOxpsECExampleCalcMinibasket();
     }
 
     public function getOxpsECExampleCalcArticle()
     {
-        return $this->moduleSettings->getOxpsECExampleCalcArticle();
+        return $this->getModuleSettings()->getOxpsECExampleCalcArticle();
     }
 }


### PR DESCRIPTION
During module activation the ViewConfig extention is loaded which tries to load the EasyCreditModuleSettings service in it's constructor which is not known to the shop at that point in time.

Fixed it by loading the service not in the constructor but when it is actually needed.