### PR TITLE
#0117128 - Fixed some details in the module

### DIFF
--- a/src/Controller/EasyCreditDispatcherController.php
+++ b/src/Controller/EasyCreditDispatcherController.php
@@ -54,6 +54,10 @@ class EasyCreditDispatcherController extends FrontendController
      */
     public function initializeandredirect()
     {
+        // Reset storage (EasyCredit transaction) for every new customer movement from payment to order controller
+        // Added because when customer changed order details like the address when the Easycredit data was already confirmed there were problems in the process
+        $this->getDicSession()->clearStorage();
+
         $this->calculateBasket($this->getApiConfig()->getEasyCreditInstalmentPaymentId(), $this->getBasket(), true);
 
         try {

--- a/src/Core/Helper/EasyCreditInitializeRequestBuilder.php
+++ b/src/Core/Helper/EasyCreditInitializeRequestBuilder.php
@@ -583,11 +583,14 @@ class EasyCreditInitializeRequestBuilder implements EasyCreditInitializeRequestB
         $contacts = [
             'email' => $customer->oxuser__oxusername->value,
         ];
+        /* EasyCredit redirect page is buggy with the telephone number at the moment - don't send a phone number and let the customer enter it on the EC site
+           Current telephone number implementation is not optimal in general with oxid having 3 different fields for phone number and the module only looking at the "landline" oxfon number instead of the mobile phone fields
         $phoneNumber = $customer->oxuser__oxfon->value;
         if ($this->isValidPhoneNumber($phoneNumber)) {
             $contacts["mobilfunknummer"] = $phoneNumber;
             $contacts["pruefungMobilfunknummerUebergehen"] = true;
         }
+        */
         return $contacts;
     }
 
@@ -615,7 +618,10 @@ class EasyCreditInitializeRequestBuilder implements EasyCreditInitializeRequestB
     {
         $customer = $this->getUser();
         return [
+            /* EasyCredit redirect page is buggy with the telephone number at the moment - don't send a phone number and let the customer enter it on the EC site
+               Current telephone number implementation is not optimal in general with oxid having 3 different fields for phone number and the module only looking at the "landline" oxfon number instead of the mobile phone fields
             'telefonnummer' => $customer->oxuser__oxfon->value,
+            */
         ];
     }
 


### PR DESCRIPTION
Fixed 2 problems in the module:

**1. Telephone number problem:**

The module sends the telephone number entered in the oxuser__oxfon input in the billing address in the checkout to the EasyCredit API.
When using an incorrect telephone number there like "12341234", the form in the EasyCredit redirect page is locked in a state where you can't finish their form because their validation is buggy.
The module will now send no telephone number at all, leading to the customer having to enter it on the EasyCredit redirect page, which does not lead to this locked validation state.
The phone implementation at the moment was subpar in general, since it only looks at 1 of the 3 telephone number fields of the Oxid shop and with oxfon being the field for the classic "landline" it is the wrong field.

**2. Problems in process with corrections on order after confirmation by EasyCredit**

When the customer chose EasyCredit and finished the EasyCredit redirect page and then decides to changes some order-details like the address on the order controller (then being redirected to user controller) and then tries to move through the EasyCredit process again, we discovered several problems leading to not being able to finish an order with EasyCredit.
Before moving through the EasyCredit process, it is now guaranteed that a new EasyCredit transaction is started by clearing the EasyCredit session every time the customer moves from payment to order controller (with redirect to EC in between).
This solved all problems we had with late changes to the order.